### PR TITLE
Trigger resize event once twitter feed has been loaded

### DIFF
--- a/twitter-user-feed.js
+++ b/twitter-user-feed.js
@@ -34,7 +34,11 @@ H5P.TwitterUserFeed = (function ($) {
 
     // notify that twitter feed has been loaded
     twttr.ready(function (twttr) {
-        twttr.events.bind('loaded', function () { self.trigger('loaded'); });
+        twttr.events.bind('loaded', function () {
+          self.trigger('loaded');
+          // trigger resize event once twitter feed has been loaded
+          self.trigger('resize');
+        });
       }
     );
 


### PR DESCRIPTION
This PR fixes issue with invisible twitter feed because of unpropper iframe height (50px - only feed heading is visible).

Here is a screenshot [http://prntscr.com/iu1vn9](http://prntscr.com/iu1vn9)